### PR TITLE
fix webpack generating window reference in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-control-parser",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A lightweight cache-control parser",
   "homepage": "https://github.com/etienne-martin/cache-control-parser",
   "keywords": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = (env, argv = {}) => {
       index: "./src/index.ts"
     },
     output: {
+      globalObject: "this",
       filename: "[name].js",
       path: path.resolve(__dirname, "dist"),
       libraryTarget: "umd"


### PR DESCRIPTION
The current build uses webpack 4, which outputs an undefined
`window` reference and causes

```
ReferenceError: window is not defined
```

to repro you can visit
https://npm.runkit.com/cache-control-parser
and click `run`